### PR TITLE
[test-manjaro-gnome] Implement Manjaro theming

### DIFF
--- a/arkdep-build.d/test-manjaro-gnome/overlay/post_bootstrap/etc/dconf/db/gnome.d/01-manjaro-theming
+++ b/arkdep-build.d/test-manjaro-gnome/overlay/post_bootstrap/etc/dconf/db/gnome.d/01-manjaro-theming
@@ -7,6 +7,7 @@ primary-color='#3465a4'
 secondary-color='#000000'
 
 [org/gnome/desktop/interface]
+color-scheme='prefer-dark'
 cursor-theme='Bibata-Modern-Classic'
 font-name='Noto Sans 11'
 monospace-font-name='Hack 11'

--- a/arkdep-build.d/test-manjaro-gnome/overlay/post_bootstrap/etc/dconf/db/gnome.d/01-manjaro-theming
+++ b/arkdep-build.d/test-manjaro-gnome/overlay/post_bootstrap/etc/dconf/db/gnome.d/01-manjaro-theming
@@ -1,0 +1,14 @@
+[org/gnome/desktop/background]
+color-shading-type='solid'
+picture-options='zoom'
+picture-uri='file:///usr/share/backgrounds/manjaro/abstract-l.png'
+picture-uri-dark='file:///usr/share/backgrounds/manjaro/abstract-d.png'
+primary-color='#3465a4'
+secondary-color='#000000'
+
+[org/gnome/desktop/interface]
+cursor-theme='Bibata-Modern-Classic'
+font-name='Noto Sans 11'
+monospace-font-name='Hack 11'
+icon-theme='Papirus-Dark-Maia'
+document-font-name='Sans 11'

--- a/arkdep-build.d/test-manjaro-gnome/overlay/post_bootstrap/etc/dconf/db/gnome.d/02-color-scheme
+++ b/arkdep-build.d/test-manjaro-gnome/overlay/post_bootstrap/etc/dconf/db/gnome.d/02-color-scheme
@@ -1,2 +1,0 @@
-[org/gnome/desktop/interface]
-color-scheme='prefer-dark'

--- a/arkdep-build.d/test-manjaro-gnome/package.list
+++ b/arkdep-build.d/test-manjaro-gnome/package.list
@@ -2,6 +2,7 @@ apparmor
 arkane-application-cleaner
 arkdep
 arkdep-libalpm-hooks
+bibata-cursor-theme
 bind
 bluez
 bluez-cups
@@ -51,6 +52,7 @@ ibus-typing-booster
 libnss-extrausers
 libva-mesa-driver
 man-db
+manjaro-gnome-backgrounds
 manjaro-zsh-config
 mesa
 mesa-vdpau
@@ -66,6 +68,7 @@ noto-fonts-emoji
 opennic-up
 openssh
 pacman-contrib
+papirus-maia-icon-theme
 pipewire
 pipewire-alsa
 pipewire-audio
@@ -85,6 +88,7 @@ terminus-font
 tpm2-tools
 tpm2-tss
 tpm2-tss-engine
+ttf-hack
 vulkan-icd-loader
 vulkan-intel
 vulkan-mesa-layers


### PR DESCRIPTION
This implements a basic Manjaro GNOME theming. Potentially dangerous theming options such as extensions, shell theme and GTK theme are not included as discussed with the Manjaro GNOME devs.